### PR TITLE
Share to other pages links not appearing on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This page is available as an easy-to-read website. Access it by clicking on [![h
   </form>
 </div>
 
-
 ## Intro
 
 This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926) with contributions from Karan Bhangui and George Stocker.
@@ -58,14 +57,16 @@ Click on these badges to see how you might be able to help:
 
 </div>
 
-
 ## How to Share
 
-+ [Share on Twitter](http://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books)
-+ [Share on Facebook](https://www.facebook.com/share.php?u=https%3A%2F%2Fgithub.com%2FEbookFoundation%2Ffree-programming-books&p[images][0]=&p[title]=Free%20Programming%20Books&p[summary]=)
-+ [Share on LinkedIn](http://www.linkedin.com/shareArticle?mini=true&url=https://github.com/EbookFoundation/free-programming-books&title=Free%20Programming%20Books&summary=&source=)
-+ [Share on Telegram](https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books)
+<div align="left" markdown="1">
 
+<a href="http://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books">Share on Twitter</a><br>
+<a href="https://www.facebook.com/share.php?u=https%3A%2F%2Fgithub.com%2FEbookFoundation%2Ffree-programming-books&p[images][0]=&p[title]=Free%20Programming%20Books&p[summary]=">Share on Facebook</a><br>
+<a href="http://www.linkedin.com/shareArticle?mini=true&url=https://github.com/EbookFoundation/free-programming-books&title=Free%20Programming%20Books&summary=&source=">Share on LinkedIn</a><br>
+<a href="https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books">Share on Telegram</a><br>
+
+</div>
 
 ## Resources
 
@@ -76,7 +77,6 @@ This project lists books and other resources grouped by genres:
 [English, By Programming Language](books/free-programming-books-langs.md)
 
 [English, By Subject](books/free-programming-books-subjects.md)
-
 
 #### Other Languages
 
@@ -120,11 +120,9 @@ This project lists books and other resources grouped by genres:
 + [Ukrainian / Українська](books/free-programming-books-uk.md)
 + [Vietnamese / Tiếng Việt](books/free-programming-books-vi.md)
 
-
 ### Cheat Sheets
 
 + [All Languages](more/free-programming-cheatsheets.md)
-
 
 ### Free Online Courses
 


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | **Add info** | Improve repo

## For resources
### Description

Shows how the links to other sites aren't working under the `Share` banner when you access the website from GitHub pages.

![GithubIssueFreeEBooks](https://user-images.githubusercontent.com/92204097/195197991-6f1a75de-9be3-4397-844e-7c5e73e2ad4d.jpg)

### Why is this valuable (or not)?

- Removes a bug from the source code
- Needs more work though to organize the links

### How do we know it's really free?

- N/A

### For book lists, is it a book? For course lists, is it a course? etc.

- N/A

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!

Closes #8099
#Hacktober